### PR TITLE
Fix dispatch() calling next() even if not defined.

### DIFF
--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -60,11 +60,11 @@ function splitURL(url) {
 module.exports = function (urls) {
     var compiled = compileKeys(flattenKeys(urls));
     return function (req, res, next) {
-        var args = [req, res];
+        var args = [req, res], isSome;
         if (next) {
             args.push(next);
         }
-        if(!compiled.some(function(x){
+        isSome = compiled.some(function(x){
             var match = x[0].exec(url.parse(req.url).pathname);
             if (match) {
                 if (!x[1] || x[1] === req.method) {
@@ -73,6 +73,7 @@ module.exports = function (urls) {
                 }
             }
             return false;
-        })) next();
+        });
+        if (!isSome && next) next();
     };
 };

--- a/test/test-dispatch.js
+++ b/test/test-dispatch.js
@@ -272,3 +272,16 @@ exports['without next function - eg, vanilla http servers'] = function (test) {
         }
     })(request, 'response');
 };
+
+exports['with named param at end'] = function (test) {
+    var request = {url: '/tests/123', method: 'GET'};
+    dispatch({
+        'GET /tests/:x': function(req, res, x){
+            test.equals(req, request);
+            test.equals(res, 'response');
+            test.equals(x, '123');
+            test.done();
+        }
+    })(request, 'response');
+};
+


### PR DESCRIPTION
Error applies only when using `dispatch()` together with the vanilla node.js `http` module. Using a URL on the form `/name/:param/` caused `dispatch()` to call `next()`, which isn't defined.