### PR TITLE
Wrap whole regexp in parentheses while adding ^$.

### DIFF
--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -34,7 +34,7 @@ function compileKeys(urls) {
     return urls.map(function (url) {
         // replace named params with regexp groups
         var pattern = url[0].replace(/\/:\w+/g, '(?:/([^\/]+))');
-        url[0] = new RegExp('^' + pattern + '$');
+        url[0] = new RegExp('^(?:' + pattern + ')$');
         return url;
     });
 }

--- a/test/test-dispatch.js
+++ b/test/test-dispatch.js
@@ -285,3 +285,26 @@ exports['with named param at end'] = function (test) {
     })(request, 'response');
 };
 
+exports['regexp with pipe'] = function (test) {
+    test.expect(2);
+    var requestFactory = function(url){ return {url: url, method: 'GET'}; };
+    var called = function(req, res){
+        test.ok(true);
+    };
+    var notCalled = function(req, res){
+        test.ok(false, 'should not be called');
+    };
+    dispatch({
+      '/x|/y': called
+    })(requestFactory('/x'), 'response');
+    dispatch({
+      '/x|/y': called
+    })(requestFactory('/y'), 'response');
+    dispatch({
+      '/x|/y': notCalled
+    })(requestFactory('/xx'), 'response');
+    dispatch({
+      '/x|/y': notCalled
+    })(requestFactory('/yy'), 'response');
+    test.done();
+};


### PR DESCRIPTION
I stumbled across it today.
I have a rule `/a(b|c)`. It matches exactly two urls: `/ab` and `/ac`.
Then I need `/d` to be handled in the exact same way as both urls above, so instead of adding another rule to dispatch object and duplicating the handler function, I modify the regexp: `/a(b|c)|/d`.
Surprise! Now `/abfoobar` also matches.
That was caused by adding `^` and `$` without wrapping everything in parens. It efectively has become `^/a(b|c)|/d$`.
Fix + test included.